### PR TITLE
Added "licensing" Page Reflecting "MIT License" 

### DIFF
--- a/app/(policy)/licensing/page.tsx
+++ b/app/(policy)/licensing/page.tsx
@@ -1,0 +1,82 @@
+import FooterApp from '@/components/FooterApp';
+import React from 'react';
+
+function Licensing() {
+  return (
+    <main>
+      <h1 className='text-white text-6xl font-extrabold text-center mt-16'>Licensing</h1>
+      <div className='flex justify-center mt-12 text-white/50 text-xl'>
+        <div className='w-[75%] flex flex-col gap-8 max-md:text-justify mb-12'>
+          
+          <p className='text-md text-white/80'>Welcome to ShareHub <br /><br />
+          ShareHub is a Project where users can create their public viewable profile containing their customizable social links and important links that they want to share with the world. It is licensed under MIT License, this page outlines the terms of the license and provides details on how to use, modify and distribute our software.</p>
+          
+          <div className='flex justify-center'>
+            <div className='w-[90%] flex flex-col gap-6'>
+            
+              <p className='text-md text-white/80'>
+                The MIT License (MIT)
+              </p>
+              
+              <p>
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+              </p>
+              
+              <p>
+                The above copyright notice and this permission notice shall be included in
+                all copies or substantial portions of the Software.
+              </p>
+              
+              <p>
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+                THE SOFTWARE.
+              </p>
+              
+              <p className='text-md text-white/80'>
+              Copyright (c) 2024 Punyakrit
+              </p>
+            </div>
+          </div>
+          
+
+          {/* Contact Section */}
+          <h2 className='text-3xl text-white/95 text-left'>Contact Us :</h2>
+          <p>If you have questions or comments about this License, please contact us at -</p>
+          <div className='flex justify-center'>
+            <div className='w-[90%] flex flex-col gap-6'>
+              <ul className='list-disc flex flex-col gap-2'>
+                <li>
+                  <span className='text-blue-500'>
+                    <a href="https://www.linkedin.com/in/punyakrit-singh-makhni/" target='_blank'>
+                      LinkedIn
+                    </a>
+                  </span>
+                </li>
+                <li>
+                  <span className='text-blue-500'>
+                    <a href="https://github.com/punyakrit/" target='_blank'>
+                      GitHub
+                    </a>
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <FooterApp />
+    </main>
+  );
+}
+
+export default Licensing;

--- a/components/FooterApp.tsx
+++ b/components/FooterApp.tsx
@@ -41,9 +41,14 @@ function FooterApp() {
                     Privacy Policy
                   </Link>
                 </li>
-                <li>
+                <li className="mb-4">
                   <Link href="/terms_conditions" target="_blank" className="transition ease duration-150 hover:text-white/65 hover:cursor-pointer">
                     Terms &amp; Conditions
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/licensing" target="_blank" className="transition ease duration-150 hover:text-white/65 hover:cursor-pointer">
+                    Licensing
                   </Link>
                 </li>
               </ul>


### PR DESCRIPTION
Hey @punyakrit | Issue Closes #134

I have added the Licensing page that reflects MIT license in footer section for Social Share Website

### Screenshots

![image](https://github.com/punyakrit/social-share/assets/101971980/da249690-165f-4127-b9c1-e6c36e8d4d3c)
![image](https://github.com/punyakrit/social-share/assets/101971980/2dd836da-7860-4c87-b639-a64737a910a9)

![image](https://github.com/punyakrit/social-share/assets/101971980/d2a4a3cc-2fdb-4cfb-b16a-a9d364c16bec)


### Screen Record
https://github.com/punyakrit/social-share/assets/101971980/802fe58a-33a6-488b-ace6-3b9e1e4ad5d9

Could you please take a look and review it, Thank You!!
