### PR TITLE
FAQ alligned properly for small screens

### DIFF
--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -8,19 +8,19 @@ export default function AccordionComponent() {
       <h1 className="text-3xl md:text-4xl font-bold text-center text-orchid mb-8 md:mb-12">Frequently Asked Questions (FAQ)</h1>
       <div className="max-w-4xl mx-auto px-4 md:px-0 text-white">
         <Accordion>
-          <AccordionItem key="1" aria-label="Accordion 1" title={<span className="text-white">What is ShareHub?</span>}>
+          <AccordionItem key="1" aria-label="Accordion 1" title={<p className="text-white text-left flex-1">What is ShareHub?</p>}>
             <p>ShareHub is a versatile platform designed for individuals and businesses to create personalized web pages. It offers customizable themes and layouts to showcase unique styles and brands effectively. Users can integrate various social media profiles for streamlined engagement and content sharing.</p>
           </AccordionItem>
-          <AccordionItem key="2" aria-label="Accordion 2" title={<span className="text-white">How can I personalize my page on ShareHub?</span>}>
+          <AccordionItem key="2" aria-label="Accordion 2" title={<p className="text-white text-left flex-1">How can I personalize my page on ShareHub?</p>}>
             <p>You can personalize your page on ShareHub by choosing from a variety of themes, layouts, and customization options. This includes uploading custom images, adjusting colors, and arranging content blocks to reflect your personal or brand identity effectively.</p>
           </AccordionItem>
-          <AccordionItem key="3" aria-label="Accordion 3" title={<span className="text-white">Does ShareHub support integration with social media platforms?</span>}>
+          <AccordionItem key="3" aria-label="Accordion 3" title={<p className="text-white text-left flex-1">Does ShareHub support integration with social media platforms?</p>}>
             <p>Yes, ShareHub seamlessly integrates with popular social media platforms such as Instagram, Twitter, Facebook, and more. This integration allows users to centralize their social media presence, making it easier for followers to connect and engage across different channels.</p>
           </AccordionItem>
-          <AccordionItem key="4" aria-label="Accordion 4" title={<span className="text-white">What types of content can I share on ShareHub?</span>}>
+          <AccordionItem key="4" aria-label="Accordion 4" title={<p className="text-white text-left flex-1">What types of content can I share on ShareHub?</p>}>
             <p>Yes, ShareHub seamlessly integrates with popular social media platforms such as Instagram, Twitter, Facebook, and more. This integration allows users to centralize their social media presence, making it easier for followers to connect and engage across different channels.</p>
           </AccordionItem>
-          <AccordionItem key="5" aria-label="Accordion 5" title={<span className="text-white">Can I track the performance of my page and content on ShareHub?</span>}>
+          <AccordionItem key="5" aria-label="Accordion 5" title={<p className="text-white text-left flex-1">Can I track the performance of my page and content on ShareHub?</p>}>
             <p>Yes, ShareHub offers robust analytics tools that provide insights into your page&apos;s performance, audience demographics, engagement metrics, and more. These analytics help you optimize your content strategy and measure the impact of your online presence effectively.</p>
           </AccordionItem>
         </Accordion>


### PR DESCRIPTION
I have perfectly aligned the text and spread button and is working for both small and large screens.
Image:

![image](https://github.com/user-attachments/assets/035a4f2d-f701-443a-aa7c-95911a89162a)

![image](https://github.com/user-attachments/assets/c7b6d9b0-1148-46df-93ae-ce49a02ec2bd)


@punyakrit Kindly see these changes and merge my pr. Fixed #204 
Thank you.