### PR TITLE
fix: prevent unnecessary API calls on profile update

### DIFF
--- a/components/dashboard/UserLinks.tsx
+++ b/components/dashboard/UserLinks.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 import React, { useState } from "react";
 import DashboardSectionComponent from "./DashboardSectionComponent";
 import { GripVertical, Link, Plus, Trash, UploadCloud } from "lucide-react";
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 
 function UserLinks({ user, session }: any) {
   const [links, setLinks] = useState(user.links || []);
+  const [prevState, setPrevState] = useState(user.links || []); // save state to check for changes
 
   async function handleImageChange(
     e: React.ChangeEvent<HTMLInputElement>,
@@ -45,9 +46,16 @@ function UserLinks({ user, session }: any) {
   async function save(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
+    const hasChanged = JSON.stringify(links) !== JSON.stringify(prevState);
+
+    // no changes
+    if (!hasChanged) return;
+
     const response = await savePageLinks(links);
-    if(response.success) toast.success(response.message);
-    else toast.error(response.message);
+    if (response.success) {
+      toast.success(response.message);
+      setPrevState(links);
+    } else toast.error(response.message);
   }
 
   function addNewLink(e: React.MouseEvent<HTMLButtonElement>) {

--- a/components/dashboard/UserLinks.tsx
+++ b/components/dashboard/UserLinks.tsx
@@ -8,6 +8,11 @@ import { ReactSortable } from "react-sortablejs";
 import { savePageLinks } from "@/actions/UserProfile";
 import { toast } from "sonner";
 
+const toastOptions = {
+  id: 0,
+  duration: 1500,
+};
+
 function UserLinks({ user, session }: any) {
   const [links, setLinks] = useState(user.links || []);
   const [prevState, setPrevState] = useState(user.links || []); // save state to check for changes
@@ -49,7 +54,10 @@ function UserLinks({ user, session }: any) {
     const hasChanged = JSON.stringify(links) !== JSON.stringify(prevState);
 
     // no changes
-    if (!hasChanged) return;
+    if (!hasChanged) {
+      toast.info("Nothing to save", toastOptions);
+      return;
+    }
 
     const response = await savePageLinks(links);
     if (response.success) {

--- a/components/dashboard/UserSettings.tsx
+++ b/components/dashboard/UserSettings.tsx
@@ -12,6 +12,11 @@ import { toast } from "sonner";
 import DashboardSectionComponent from "./DashboardSectionComponent";
 import UserSocialForm from "./UserSocialForm";
 
+const toastOptions = {
+  id: 0,
+  duration: 1500,
+};
+
 function UserSettings({ user, session }: any) {
   const [bgType, setBgType] = useState(user.bgType);
   const [bgColor, setBgColor] = useState(user.bgColor);
@@ -43,7 +48,10 @@ function UserSettings({ user, session }: any) {
     );
 
     // no changes
-    if (!hasChanged) return;
+    if (!hasChanged) {
+      toast.info("Nothing to save", toastOptions);
+      return;
+    }
 
     try {
       const result = await UserProfile(formData);

--- a/components/dashboard/UserSettings.tsx
+++ b/components/dashboard/UserSettings.tsx
@@ -19,6 +19,7 @@ function UserSettings({ user, session }: any) {
   const [avatarImage, setAvatarImage] = useState(
     user.avatarImage || session?.user?.image
   );
+  const [prevState, setPrevState] = useState(user); // save state to check for changes
 
   useEffect(() => {
     setBgType(user.bgType);
@@ -34,12 +35,24 @@ function UserSettings({ user, session }: any) {
     formData.set("bgImage", bgImage); // Set the bgImage in formData
     formData.set("avatarImage", avatarImage);
 
+    const currentState = [...formData.entries()];
+
+    // compare form values with previous state
+    const hasChanged = currentState.some(
+      ([key, value]) => prevState[key] !== value
+    );
+
+    // no changes
+    if (!hasChanged) return;
+
     try {
       const result = await UserProfile(formData);
       console.log(result);
 
-      if(result.success) toast.success(result.message);
-      else toast.error(result.message);
+      if (result.success) {
+        toast.success(result.message);
+        setPrevState(Object.fromEntries(currentState));
+      } else toast.error(result.message);
     } catch (error: any) {
       console.error("Error saving user profile:", error);
       toast.error(error?.message);
@@ -57,9 +70,9 @@ function UserSettings({ user, session }: any) {
           body: data,
         });
         const result = await res.json();
-        
+
         // success
-        if (result.link) toast.success("Image uploaded successfully");
+        if (result.link) toast.success("Image uploaded. Please save details");
         //error
         else toast.error("Failed to upload image");
 
@@ -83,7 +96,7 @@ function UserSettings({ user, session }: any) {
         const result = await res.json();
 
         // success
-        if (result.link) toast.success("Image uploaded successfully");
+        if (result.link) toast.success("Image uploaded. Please save details");
         //error
         else toast.error("Failed to upload image");
 
@@ -101,7 +114,7 @@ function UserSettings({ user, session }: any) {
 
   return (
     <DashboardSectionComponent>
-      <form onSubmit={handleSubmit} >
+      <form onSubmit={handleSubmit}>
         <div
           className="rounded-t-3xl -mt-1 min-h-[250px] py-5 flex justify-center items-center bg-cover bg-center"
           style={style}

--- a/components/dashboard/UserSocialForm.tsx
+++ b/components/dashboard/UserSocialForm.tsx
@@ -63,6 +63,11 @@ const allButtons = [
   },
 ];
 
+const toastOptions = {
+  id: 0,
+  duration: 1500,
+};
+
 function UserSocialForm({ user, session }: any) {
   const pageSavedButton = user.button ? Object.keys(user.button) : [];
   const buttonInfo = pageSavedButton
@@ -96,7 +101,10 @@ function UserSocialForm({ user, session }: any) {
     const hasChanged = // stringify works because order is also important
       JSON.stringify(currentState) !== JSON.stringify(prevState);
 
-    if (!hasChanged) return;
+    if (!hasChanged) {
+      toast.info("Nothing to save", toastOptions);
+      return;
+    }
 
     const result = await saveSocials(formData);
 

--- a/components/dashboard/UserSocialForm.tsx
+++ b/components/dashboard/UserSocialForm.tsx
@@ -70,6 +70,9 @@ function UserSocialForm({ user, session }: any) {
     .filter(Boolean); // Ensure no undefined values are included
 
   const [activeButtons, setActiveButtons] = useState<any[]>(buttonInfo);
+  const [prevState, setPrevState] = useState<any[]>(
+    user?.button ? [...Object.entries(user.button)] : []
+  ); // save state to check for changes
 
   const availableButtons = allButtons.filter(
     (button) =>
@@ -88,10 +91,19 @@ function UserSocialForm({ user, session }: any) {
   async function saveDetails(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
+    const currentState = [...formData.entries()];
+
+    const hasChanged = // stringify works because order is also important
+      JSON.stringify(currentState) !== JSON.stringify(prevState);
+
+    if (!hasChanged) return;
+
     const result = await saveSocials(formData);
-    
-    if(result.success) toast.success(result.message);
-    else toast.error(result.message);
+
+    if (result.success) {
+      toast.success(result.message);
+      setPrevState(currentState);
+    } else toast.error(result.message);
   }
 
   function removeButton(item: any) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11349,6 +11349,126 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz",
+      "integrity": "sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
+      "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
+      "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
+      "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz",
+      "integrity": "sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz",
+      "integrity": "sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
+      "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
+      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
### Related Issue

fixes #210 

### Description

- Implemented a check to compare the new profile data with the previous state before making an API call to save profile updates.
- This optimization prevents redundant API calls when there are no actual changes made to the profile.
- Added toast to indicate no changes.
- Prevent displaying multiple toasts on repeated clicks when no changes.

### Screenshots
#### 1. User Profile

https://github.com/user-attachments/assets/a52a0df3-c7a4-451c-840d-0fae41eed0d5

#### 2. User Socials

https://github.com/user-attachments/assets/b417761f-ca4b-410f-b93a-e9a63a1de269

##### 3. User Links

https://github.com/user-attachments/assets/529f3d22-7610-496d-8b47-c1a06f58aa43

